### PR TITLE
Fix: Conditionally modify sys.path in main.py for direct execution

### DIFF
--- a/src/game_engine.py
+++ b/src/game_engine.py
@@ -1,8 +1,8 @@
 import curses
 
-from .parser import Parser
-from .player import Player
-from .world_generator import WorldGenerator
+from src.parser import Parser
+from src.player import Player
+from src.world_generator import WorldGenerator
 
 
 class GameEngine:

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,16 @@
-from .game_engine import GameEngine
+import sys
+import os
+
+if __name__ == "__main__":
+    # Get the absolute path of the directory containing main.py (src)
+    src_dir = os.path.dirname(os.path.abspath(__file__))
+    # Get the absolute path of the project root (parent of src)
+    project_root = os.path.dirname(src_dir)
+    # Add project_root to the beginning of sys.path
+    if project_root not in sys.path:
+        sys.path.insert(0, project_root)
+
+from src.game_engine import GameEngine
 
 if __name__ == "__main__":
     # You can adjust map_width and map_height here if desired

--- a/src/player.py
+++ b/src/player.py
@@ -1,5 +1,5 @@
-from .item import Item
-from .monster import Monster
+from src.item import Item
+from src.monster import Monster
 
 
 class Player:

--- a/src/world_generator.py
+++ b/src/world_generator.py
@@ -1,8 +1,8 @@
 import random
 
-from .item import Item
-from .monster import Monster
-from .world_map import WorldMap
+from src.item import Item
+from src.monster import Monster
+from src.world_map import WorldMap
 
 
 class WorldGenerator:

--- a/src/world_map.py
+++ b/src/world_map.py
@@ -1,6 +1,6 @@
-from .item import Item
-from .monster import Monster
-from .tile import Tile
+from src.item import Item
+from src.monster import Monster
+from src.tile import Tile
 
 
 class WorldMap:


### PR DESCRIPTION
Reverted intra-package imports to be absolute (e.g., `from src.module`). Added logic to `src/main.py` to prepend the project root directory to `sys.path` when `main.py` is executed as the main script.

This allows `python src/main.py` (and by extension, `uv run python src/main.py`) to correctly locate the `src` package and its modules, resolving the `ModuleNotFoundError` without relying on relative imports or requiring execution with `python -m`.