### PR TITLE
Fix: Correct curses.curs_set calls in game_engine

### DIFF
--- a/src/game_engine.py
+++ b/src/game_engine.py
@@ -31,7 +31,7 @@ class GameEngine:
 
         command_tuple = None
         if self.input_mode == "movement":
-            self.stdscr.curs_set(0)
+            curses.curs_set(0)
             if key == "KEY_UP" or key == "w" or key == "W":
                 command_tuple = ("move", "north")
             elif key == "KEY_DOWN" or key == "s" or key == "S":
@@ -45,11 +45,11 @@ class GameEngine:
             ):  # 'q' in movement mode switches to command mode
                 self.input_mode = "command"
                 self.current_command_buffer = ""
-                self.stdscr.curs_set(1)  # Show cursor
+                curses.curs_set(1)  # Show cursor
             return command_tuple
 
         elif self.input_mode == "command":
-            self.stdscr.curs_set(1)
+            curses.curs_set(1)
             if len(key) == 1 and key.isprintable():
                 self.current_command_buffer += key
             elif (
@@ -58,7 +58,7 @@ class GameEngine:
                 command_to_parse = self.current_command_buffer
                 self.current_command_buffer = ""
                 self.input_mode = "movement"
-                self.stdscr.curs_set(0)
+                curses.curs_set(0)
                 command_tuple = self.parser.parse_command(command_to_parse)
                 return command_tuple
             elif (
@@ -68,11 +68,11 @@ class GameEngine:
             elif key == "\x1b":  # Escape key
                 self.current_command_buffer = ""
                 self.input_mode = "movement"
-                self.stdscr.curs_set(0)
+                curses.curs_set(0)
             elif key == "q" or key == "Q":  # 'q' or 'Q' to exit command mode
                 self.current_command_buffer = ""
                 self.input_mode = "movement"
-                self.stdscr.curs_set(0)
+                curses.curs_set(0)
             elif key == "KEY_RESIZE":  # Handle resize event
                 self.stdscr.clear()
                 # The next render_map call will redraw based on new screen size

--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,15 @@
+import sys
+import os
+
+if __name__ == "__main__":
+    # Get the absolute path of the directory containing main.py (src)
+    src_dir = os.path.dirname(os.path.abspath(__file__))
+    # Get the absolute path of the project root (parent of src)
+    project_root = os.path.dirname(src_dir)
+    # Add project_root to the beginning of sys.path
+    if project_root not in sys.path:
+        sys.path.insert(0, project_root)
+
 from src.game_engine import GameEngine
 
 if __name__ == "__main__":


### PR DESCRIPTION
I changed incorrect calls of `self.stdscr.curs_set()` to the proper `curses.curs_set()` within the `handle_input_and_get_command` method in `src/game_engine.py`.

The `curs_set` function is a module-level function in `curses` and not a method of window objects. This change resolves the `AttributeError` that occurred upon keypress after the game started.