### PR TITLE
Fix: Use standard width characters for map symbols

### DIFF
--- a/src/game_engine.py
+++ b/src/game_engine.py
@@ -16,7 +16,7 @@ class GameEngine:
         self.world_generator = WorldGenerator()
         self.parser = Parser()
         self.debug_mode = debug_mode
-        self.PLAYER_SYMBOL = "🧑"
+        self.PLAYER_SYMBOL = "@"
 
         if not self.debug_mode:
             self.stdscr = curses.initscr()

--- a/src/tile.py
+++ b/src/tile.py
@@ -1,6 +1,6 @@
 ENTITY_SYMBOLS = {
-    "monster": "👹",
-    "item": "💰",
+    "monster": "M",
+    "item": "$",
 }
 TILE_SYMBOLS = {
     "wall": "#",  # Using '#' for wall character as per new instructions


### PR DESCRIPTION
Replaced wide emoji characters for player, monster, and item symbols with standard ASCII characters to ensure consistent alignment in the map display, regardless of font.

- Player "🧑" changed to "@" in `src/game_engine.py`
- Monster "👹" changed to "M" in `src/tile.py`
- Item "💰" changed to "$" in `src/tile.py`

This resolves the visual offset issue caused by uneven character widths.