### PR TITLE
Fix: Ensure --seed flag provides deterministic game world

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -171,6 +171,7 @@ if __name__ == "__main__":
             debug_mode=False,
             ai_active=args.ai,
             ai_sleep_duration=args.ai_sleep,
+            seed=args.seed,
         )
         try:
             game.run()

--- a/src/map_builders/world_builder.py
+++ b/src/map_builders/world_builder.py
@@ -203,13 +203,10 @@ class WorldBuilder:
         self._initialize_world()
 
         for floor_id in range(self.num_floors):
-            single_floor_seed = (
-                random.randint(0, 2**32 - 1) if self.seed is not None else None
-            )
             builder = SingleFloorBuilder(
                 self.width,
                 self.height,
-                seed=single_floor_seed,
+                seed=self.seed,
                 existing_map=self.world_maps[floor_id],
             )
             world_map, floor_start_pos, floor_poi_pos = builder.build()

--- a/tests/map_builders/test_world_builder.py
+++ b/tests/map_builders/test_world_builder.py
@@ -125,3 +125,28 @@ def test_all_floors_connected():
                 q.append(v_neighbor)
 
     assert len(visited) == num_floors, f"Not all floors connected: {visited}"
+
+
+def test_world_builder_with_seed_is_deterministic():
+    width, height, num_floors, seed = 20, 20, 3, 123
+    builder1 = WorldBuilder(width, height, num_floors=num_floors, seed=seed)
+    world_maps1, player_start1, amulet_pos1, _ = builder1.build()
+
+    builder2 = WorldBuilder(width, height, num_floors=num_floors, seed=seed)
+    world_maps2, player_start2, amulet_pos2, _ = builder2.build()
+
+    assert player_start1 == player_start2
+    assert amulet_pos1 == amulet_pos2
+    assert len(world_maps1) == len(world_maps2)
+
+    for floor_id in world_maps1:
+        assert floor_id in world_maps2
+        map1 = world_maps1[floor_id]
+        map2 = world_maps2[floor_id]
+        for y in range(height):
+            for x in range(width):
+                tile1 = map1.get_tile(x, y)
+                tile2 = map2.get_tile(x, y)
+                assert tile1.type == tile2.type
+                assert tile1.is_portal == tile2.is_portal
+                assert tile1.portal_to_floor_id == tile2.portal_to_floor_id

--- a/tests/test_game_engine.py
+++ b/tests/test_game_engine.py
@@ -298,5 +298,37 @@ class TestGameEngine(unittest.TestCase):
         self.assertGreaterEqual(self.mock_renderer_instance.render_all.call_count, 2)
 
 
+    @patch("src.game_engine.curses")
+    def test_game_engine_with_seed_is_deterministic(self, mock_curses):
+        # First game engine
+        game1 = GameEngine(map_width=20, map_height=10, seed=12345, debug_mode=True)
+
+        # Second game engine with the same seed
+        game2 = GameEngine(map_width=20, map_height=10, seed=12345, debug_mode=True)
+
+        # Compare player start positions
+        self.assertEqual(game1.player.x, game2.player.x)
+        self.assertEqual(game1.player.y, game2.player.y)
+        self.assertEqual(game1.player.current_floor_id, game2.player.current_floor_id)
+
+        # Compare winning positions
+        self.assertEqual(game1.winning_full_pos, game2.winning_full_pos)
+
+        # Compare number of floors
+        self.assertEqual(len(game1.world_maps), len(game2.world_maps))
+
+        # Compare map layouts tile by tile
+        for floor_id in game1.world_maps:
+            map1 = game1.world_maps[floor_id]
+            map2 = game2.world_maps[floor_id]
+            for y in range(map1.height):
+                for x in range(map1.width):
+                    tile1 = map1.get_tile(x, y)
+                    tile2 = map2.get_tile(x, y)
+                    self.assertEqual(tile1.type, tile2.type)
+                    self.assertEqual(tile1.is_portal, tile2.is_portal)
+                    self.assertEqual(tile1.portal_to_floor_id, tile2.portal_to_floor_id)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_world_generator.py
+++ b/tests/test_world_generator.py
@@ -1,5 +1,3 @@
-import random
-
 from src.world_generator import WorldGenerator
 from src.world_map import WorldMap
 
@@ -37,20 +35,35 @@ def test_generate_world_returns_correct_types():
 
 def test_world_generation_with_seed_is_deterministic():
     width, height, seed = 25, 15, 12345
-    generator = WorldGenerator()
-    maps1, ps1, ap1, fd1 = generator.generate_world(width, height, seed=seed)
-    random.seed(seed)  # Reset seed for fair comparison
-    maps2, ps2, ap2, fd2 = generator.generate_world(width, height, seed=seed)
+    generator1 = WorldGenerator()
+    maps1, ps1, ap1, fd1 = generator1.generate_world(width, height, seed=seed)
+
+    generator2 = WorldGenerator()
+    maps2, ps2, ap2, fd2 = generator2.generate_world(width, height, seed=seed)
 
     assert ps1 == ps2
     assert ap1 == ap2
     assert len(maps1) == len(maps2)
 
+    # Compare floor details
     fd1_sorted = sorted(fd1, key=lambda x: x["id"])
     fd2_sorted = sorted(fd2, key=lambda x: x["id"])
     for d1, d2 in zip(fd1_sorted, fd2_sorted):
         assert d1["start"] == d2["start"]
         assert d1["poi"] == d2["poi"]
+
+    # Compare maps tile by tile
+    for floor_id in maps1:
+        assert floor_id in maps2
+        map1 = maps1[floor_id]
+        map2 = maps2[floor_id]
+        for y in range(height):
+            for x in range(width):
+                tile1 = map1.get_tile(x, y)
+                tile2 = map2.get_tile(x, y)
+                assert tile1.type == tile2.type
+                assert tile1.is_portal == tile2.is_portal
+                assert tile1.portal_to_floor_id == tile2.portal_to_floor_id
 
 
 def test_world_generation_without_seed_is_non_deterministic():


### PR DESCRIPTION
The --seed flag was not working as expected, and this commit fixes the issue.

The main changes are:
- The --seed flag is now correctly passed to the GameEngine in all game modes.
- The WorldBuilder now uses the provided seed to generate each floor, ensuring that the entire world generation is deterministic.
- The tests for the --seed flag have been improved to be more comprehensive and now verify that the generated worlds are identical.