### PR TITLE
Fix: Handle weapon equipping when no weapon is equipped

### DIFF
--- a/src/ai_logic/states/common_actions.py
+++ b/src/ai_logic/states/common_actions.py
@@ -22,10 +22,10 @@ def equip_better_weapon(ai_logic: "AILogic") -> Optional[Tuple[str, str]]:
     for item in ai_logic.player.inventory:
         if item.properties.get("type") == "weapon":
             current_attack_bonus = 0
-            if ai_logic.player.equipped_weapon:
-                current_attack_bonus = ai_logic.player.equipped_weapon.properties.get(
-                    "attack_bonus", 0
-                )
+            if ai_logic.player.equipment["main_hand"]:
+                current_attack_bonus = ai_logic.player.equipment[
+                    "main_hand"
+                ].properties.get("attack_bonus", 0)
 
             new_weapon_attack_bonus = item.properties.get("attack_bonus", 0)
             if new_weapon_attack_bonus > current_attack_bonus:

--- a/tests/ai_logic/states/test_common_actions.py
+++ b/tests/ai_logic/states/test_common_actions.py
@@ -1,0 +1,37 @@
+import unittest
+from unittest.mock import MagicMock, PropertyMock
+
+from src.ai_logic.states import common_actions
+from src.equippable import Equippable
+from src.player import Player
+
+
+class TestCommonActions(unittest.TestCase):
+    def test_equip_better_weapon_no_weapon_equipped(self):
+        # Arrange
+        player = Player(x=0, y=0, current_floor_id=0, health=10)
+        player.equipment = {"main_hand": None}
+
+        weapon = Equippable(
+            name="Sword",
+            description="A shiny sword.",
+            properties={
+                "type": "weapon",
+                "attack_bonus": 10,
+                "slot": "main_hand",
+            },
+        )
+        player.inventory.append(weapon)
+
+        ai_logic = MagicMock()
+        type(ai_logic).player = PropertyMock(return_value=player)
+
+        # Act
+        action = common_actions.equip_better_weapon(ai_logic)
+
+        # Assert
+        self.assertEqual(action, ("use", "Sword"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This commit fixes a bug that caused the game to crash when the AI tried to equip a weapon when the player had no weapon equipped.

The bug was caused by an `AttributeError` in the `equip_better_weapon` function in `src/ai_logic/states/common_actions.py`. The code was trying to access the `equipped_weapon` attribute of the `Player` object, which does not exist.

The fix is to check the `main_hand` slot of the `equipment` dictionary instead.

A new test has been added to cover this scenario.