### PR TITLE
Fix inventory command crash and improve test coverage

### DIFF
--- a/src/commands/drop_command.py
+++ b/src/commands/drop_command.py
@@ -36,10 +36,13 @@ class DropCommand(Command):
             self.message_log.add_message("Drop what?")
             return {"game_over": False}
 
-        item_is_equipped_weapon = False
-        if self.player.equipped_weapon and self.argument:
-            if self.player.equipped_weapon.name.lower() == self.argument.lower():
-                item_is_equipped_weapon = True
+        item_is_equipped = (
+            self.player.equipment["main_hand"] is not None
+            and self.player.equipment["main_hand"].name.lower() == self.argument.lower()
+        ) or (
+            self.player.equipment["off_hand"] is not None
+            and self.player.equipment["off_hand"].name.lower() == self.argument.lower()
+        )
 
         dropped_item = self.player.drop_item(self.argument)
 
@@ -47,7 +50,7 @@ class DropCommand(Command):
             self.message_log.add_message(f"You don't have a {self.argument} to drop.")
             return {"game_over": False}
 
-        if item_is_equipped_weapon:
+        if item_is_equipped:
             self.message_log.add_message(f"You unequip the {dropped_item.name}.")
 
         tile = self.world_map.get_tile(self.player.x, self.player.y)

--- a/src/commands/inventory_command.py
+++ b/src/commands/inventory_command.py
@@ -38,7 +38,7 @@ class InventoryCommand(Command):
             inventory_display = []
             for item_obj in self.player.inventory:
                 display_name = item_obj.name
-                if self.player.equipped_weapon == item_obj:
+                if item_obj in self.player.equipment.values():
                     display_name += " (equipped)"
                 inventory_display.append(display_name)
             self.message_log.add_message(f"Inventory: {', '.join(inventory_display)}")

--- a/tests/commands/test_inventory_command.py
+++ b/tests/commands/test_inventory_command.py
@@ -1,0 +1,99 @@
+import unittest
+from unittest.mock import MagicMock
+
+from src.commands.inventory_command import InventoryCommand
+from src.equippable import Equippable
+from src.item import Item
+from src.message_log import MessageLog
+from src.player import Player
+from src.world_map import WorldMap
+
+
+class TestInventoryCommand(unittest.TestCase):
+    def setUp(self):
+        self.player = Player(x=1, y=1, current_floor_id=0, health=10)
+        self.world_map = WorldMap(width=10, height=10)
+        self.message_log = MagicMock(spec=MessageLog)
+        self.winning_position = (9, 9, 0)
+
+    def test_inventory_empty(self):
+        cmd = InventoryCommand(
+            player=self.player,
+            world_map=self.world_map,
+            message_log=self.message_log,
+            winning_position=self.winning_position,
+        )
+        result = cmd.execute()
+        self.message_log.add_message.assert_called_with("Your inventory is empty.")
+        self.assertFalse(result.get("game_over", False))
+
+    def test_inventory_with_items_not_equipped(self):
+        self.player.inventory.append(Item("Potion", "A healing potion", {}))
+        self.player.inventory.append(Item("Scroll", "A magic scroll", {}))
+        cmd = InventoryCommand(
+            player=self.player,
+            world_map=self.world_map,
+            message_log=self.message_log,
+            winning_position=self.winning_position,
+        )
+        result = cmd.execute()
+        self.message_log.add_message.assert_called_with("Inventory: Potion, Scroll")
+        self.assertFalse(result.get("game_over", False))
+
+    def test_inventory_with_equipped_weapon(self):
+        weapon = Equippable(
+            "Sword",
+            "A sharp sword",
+            {"slot": "main_hand", "attack_bonus": 5},
+        )
+        self.player.inventory.append(weapon)
+        self.player.equipment["main_hand"] = weapon
+        cmd = InventoryCommand(
+            player=self.player,
+            world_map=self.world_map,
+            message_log=self.message_log,
+            winning_position=self.winning_position,
+        )
+        result = cmd.execute()
+        self.message_log.add_message.assert_called_with("Inventory: Sword (equipped)")
+        self.assertFalse(result.get("game_over", False))
+
+    def test_inventory_with_equipped_shield(self):
+        shield = Equippable(
+            "Shield",
+            "A sturdy shield",
+            {"slot": "off_hand", "defense_bonus": 5},
+        )
+        self.player.inventory.append(shield)
+        self.player.equipment["off_hand"] = shield
+        cmd = InventoryCommand(
+            player=self.player,
+            world_map=self.world_map,
+            message_log=self.message_log,
+            winning_position=self.winning_position,
+        )
+        result = cmd.execute()
+        self.message_log.add_message.assert_called_with("Inventory: Shield (equipped)")
+        self.assertFalse(result.get("game_over", False))
+
+    def test_inventory_with_equipped_helmet(self):
+        helmet = Equippable(
+            "Helmet",
+            "A sturdy helmet",
+            {"slot": "head", "defense_bonus": 3},
+        )
+        self.player.inventory.append(helmet)
+        self.player.equipment["head"] = helmet
+        cmd = InventoryCommand(
+            player=self.player,
+            world_map=self.world_map,
+            message_log=self.message_log,
+            winning_position=self.winning_position,
+        )
+        result = cmd.execute()
+        self.message_log.add_message.assert_called_with("Inventory: Helmet (equipped)")
+        self.assertFalse(result.get("game_over", False))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_command_processor.py
+++ b/tests/test_command_processor.py
@@ -18,7 +18,10 @@ class TestCommandProcessor(unittest.TestCase):
         self.mock_player.y = 1
         self.mock_player.health = 100
         self.mock_player.inventory = []
-        self.mock_player.equipped_weapon = None
+        self.mock_player.equipment = {
+            "main_hand": None,
+            "off_hand": None,
+        }
 
         self.mock_world_map = MagicMock(spec=WorldMap)
         self.mock_world_map.get_tile = MagicMock()


### PR DESCRIPTION
This commit fixes a crash in the inventory command that occurred when the player had an equipped item. The command was trying to access a non-existent `equipped_weapon` attribute on the `Player` object.

The fix replaces the erroneous attribute access with a check of the `equipment` dictionary on the `Player` object. This ensures that all equipped items are correctly identified, regardless of their slot.

Additionally, this commit:
- Adds a new test file for the inventory command with comprehensive test cases.
- Fixes a related bug in the drop command that also used the `equipped_weapon` attribute.
- Updates the mock player in the command processor tests to include the `equipment` attribute.