### PR TITLE
I've addressed an issue where the AI was getting stuck in a loop.

### DIFF
--- a/src/ai_logic/states/survival_state.py
+++ b/src/ai_logic/states/survival_state.py
@@ -82,26 +82,20 @@ class SurvivalState(AIState):
         # 1. Survival: Find health potions if low on health
         targets.extend(
             self.ai_logic.target_finder.find_health_potions(
-                player_pos_xy, player_floor_id
+                player_pos_xy, player_floor_id, same_floor_only=True
             )
         )
         # 2. Quest Items
         targets.extend(
-            self.ai_logic.target_finder.find_quest_items(player_pos_xy, player_floor_id)
-        )
-        # 3. Other targets
-        targets.extend(
-            self.ai_logic.explorer.find_unvisited_portals(
-                player_pos_xy, player_floor_id
+            self.ai_logic.target_finder.find_quest_items(
+                player_pos_xy, player_floor_id, same_floor_only=True
             )
         )
+        # 3. Other items
         targets.extend(
-            self.ai_logic.explorer.find_portal_to_unexplored_floor(
-                player_pos_xy, player_floor_id
+            self.ai_logic.target_finder.find_other_items(
+                player_pos_xy, player_floor_id, same_floor_only=True
             )
-        )
-        targets.extend(
-            self.ai_logic.target_finder.find_other_items(player_pos_xy, player_floor_id)
         )
         return targets
 

--- a/src/ai_logic/target_finder.py
+++ b/src/ai_logic/target_finder.py
@@ -17,10 +17,13 @@ class TargetFinder:
         player_floor_id: int,
         item_filter: Callable[["Item"], bool],
         target_type: str,
+        same_floor_only: bool = False,
     ) -> List[Tuple[int, int, int, str, int]]:
         targets = []
         for floor_id, ai_map in self.ai_visible_maps.items():
             if not ai_map:
+                continue
+            if same_floor_only and floor_id != player_floor_id:
                 continue
             for y, x in ai_map.iter_coords():
                 tile = ai_map.get_tile(x, y)
@@ -34,17 +37,24 @@ class TargetFinder:
         return targets
 
     def find_quest_items(
-        self, player_pos_xy: Tuple[int, int], player_floor_id: int
+        self,
+        player_pos_xy: Tuple[int, int],
+        player_floor_id: int,
+        same_floor_only: bool = False,
     ) -> List[Tuple[int, int, int, str, int]]:
         return self._find_items(
             player_pos_xy,
             player_floor_id,
             lambda item: item.properties.get("type") == "quest",
             "quest_item",
+            same_floor_only,
         )
 
     def find_health_potions(
-        self, player_pos_xy: Tuple[int, int], player_floor_id: int
+        self,
+        player_pos_xy: Tuple[int, int],
+        player_floor_id: int,
+        same_floor_only: bool = False,
     ) -> List[Tuple[int, int, int, str, int]]:
         low_health_threshold = self.player.max_health * 0.5
         if self.player.health >= low_health_threshold:
@@ -56,10 +66,14 @@ class TargetFinder:
             lambda item: "health potion" in item.name.lower()
             and item.properties.get("type") == "heal",
             "health_potion",
+            same_floor_only,
         )
 
     def find_other_items(
-        self, player_pos_xy: Tuple[int, int], player_floor_id: int
+        self,
+        player_pos_xy: Tuple[int, int],
+        player_floor_id: int,
+        same_floor_only: bool = False,
     ) -> List[Tuple[int, int, int, str, int]]:
         def item_filter(item: "Item") -> bool:
             is_potion_full_health = (
@@ -71,7 +85,7 @@ class TargetFinder:
             return not (is_potion_full_health or is_quest_item)
 
         return self._find_items(
-            player_pos_xy, player_floor_id, item_filter, "other_item"
+            player_pos_xy, player_floor_id, item_filter, "other_item", same_floor_only
         )
 
     def find_monsters(

--- a/src/commands/move_command.py
+++ b/src/commands/move_command.py
@@ -46,6 +46,7 @@ class MoveCommand(Command):
             return {"game_over": current_game_over_state}
 
         new_x, new_y = self.player.x + dx, self.player.y + dy
+        floor_before_move = self.player.current_floor_id
 
         # world_map is the map of the player's current floor.
         if self.world_map.is_valid_move(new_x, new_y):
@@ -67,6 +68,10 @@ class MoveCommand(Command):
                 self.message_log.add_message(
                     f"You step through the portal to floor {new_floor_id}!"
                 )
+                if self.game_engine and self.game_engine.ai_logic:
+                    self.game_engine.ai_logic.explorer.mark_portal_as_visited(
+                        new_x, new_y, floor_before_move
+                    )
                 # GameEngine handles fog of war for the new floor.
                 # CommandProcessor provides the correct map for the next command.
             elif target_tile and target_tile.monster:

--- a/tests/commands/test_move_command.py
+++ b/tests/commands/test_move_command.py
@@ -121,6 +121,36 @@ class TestMoveCommand(unittest.TestCase):
         )
         self.assertFalse(result.get("game_over", False))
 
+    def test_portal_gets_marked_as_visited_by_ai(self):
+        # Setup AI logic and explorer
+        ai_logic_mock = MagicMock()
+        game_engine_mock = MagicMock()
+        game_engine_mock.ai_logic = ai_logic_mock
+
+        # Player setup
+        self.player.x, self.player.y = 0, 0
+        self.player.current_floor_id = 0
+
+        # Portal setup
+        portal_tile_f0 = Tile(tile_type="portal", portal_to_floor_id=1)
+        self.world_maps[0].grid[0][1] = portal_tile_f0
+        self.world_maps[1] = WorldMap(3, 3)
+
+        move_cmd = MoveCommand(
+            player=self.player,
+            world_map=self.world_maps[0],
+            message_log=self.message_log,
+            winning_position=self.winning_position,
+            argument="east",
+            world_maps=self.world_maps,
+            game_engine=game_engine_mock,
+        )
+
+        move_cmd.execute()
+
+        # Verify that the explorer's method was called
+        ai_logic_mock.explorer.mark_portal_as_visited.assert_called_once_with(1, 0, 0)
+
     def test_move_to_winning_position_on_correct_floor(self):
         self.player.x, self.player.y = 1, 2
         self.player.current_floor_id = 0


### PR DESCRIPTION
The AI was caught in a cycle within its "SurvivalState," repeatedly using a portal to try and reach an item on a different floor.

To fix this, I've adjusted the `SurvivalState` to only consider targets located on the current floor. This prevents the AI from attempting to path to other floors and getting trapped in portal loops.

Here are the changes I made:
- I modified `src/commands/move_command.py` to mark portals as visited.
- I added a test to `tests/commands/test_move_command.py` to verify this change.
- I updated `src/ai_logic/states/survival_state.py` to only consider targets on the current floor.
- I modified `src/ai_logic/target_finder.py` to accept a `same_floor_only` argument.