### PR TITLE
Fix monster duplication bug

### DIFF
--- a/src/commands/move_command.py
+++ b/src/commands/move_command.py
@@ -100,6 +100,8 @@ class MoveCommand(Command):
                 if isinstance(self.entity, Monster):
                     self.world_map.remove_monster(self.entity.x, self.entity.y)
                     self.world_map.place_monster(self.entity, new_x, new_y)
+                    self.entity.x = new_x
+                    self.entity.y = new_y
                 elif isinstance(self.entity, Player):
                     self.entity.move(dx, dy)
                     self.message_log.add_message(f"You move {self.argument}.")

--- a/tests/commands/test_move_command.py
+++ b/tests/commands/test_move_command.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 from src.commands.move_command import MoveCommand
 from src.item import Item  # Added Item import
 from src.message_log import MessageLog
+from src.monster import Monster
 from src.player import Player
 from src.tile import Tile
 from src.world_map import WorldMap
@@ -181,6 +182,31 @@ class TestMoveCommand(unittest.TestCase):
         self.assertFalse(
             result.get("game_over", False)
         )  # Game over not set by move, but by take.
+
+    def test_monster_move(self):
+        monster = Monster(name="Goblin", health=10, attack_power=2, x=1, y=1)
+        self.world_map_f0.place_monster(monster, 1, 1)
+
+        move_cmd = MoveCommand(
+            player=self.player,
+            world_map=self.world_map_f0,
+            message_log=self.message_log,
+            winning_position=self.winning_position,
+            argument="north",
+            entity=monster,
+        )
+        move_cmd.execute()
+
+        self.assertEqual(monster.x, 1)
+        self.assertEqual(monster.y, 0)
+        self.assertIsNone(self.world_map_f0.get_tile(1, 1).monster)
+        self.assertIsNotNone(self.world_map_f0.get_tile(1, 0).monster)
+        self.assertEqual(self.world_map_f0.get_tile(1, 0).monster.name, "Goblin")
+
+        # Check for duplicates
+        monsters_on_map = self.world_map_f0.get_monsters()
+        self.assertEqual(len(monsters_on_map), 1)
+        self.assertEqual(monsters_on_map[0], monster)
 
 
 if __name__ == "__main__":

--- a/tests/test_tile.py
+++ b/tests/test_tile.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 from src.tile import ENTITY_SYMBOLS, TILE_SYMBOLS, Tile
 
 
@@ -13,9 +15,6 @@ def test_tile_initialization_custom():
     assert tile.type == "wall"
     assert tile.item is None
     assert tile.monster is None
-
-
-from unittest.mock import MagicMock
 
 
 def test_get_display_info_monster():


### PR DESCRIPTION
When a monster moved, it was not being removed from its previous position on the map, causing it to be duplicated. This commit fixes the bug by updating the monster's coordinates after it has been moved.

A test case has been added to `tests/commands/test_move_command.py` to ensure that monsters are not duplicated when they move.