### PR TITLE
Fix player movement on map

### DIFF
--- a/src/actions/move.py
+++ b/src/actions/move.py
@@ -1,0 +1,114 @@
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+
+if TYPE_CHECKING:
+    from src.game_engine import GameEngine
+    from src.message_log import MessageLog
+    from src.monster import Monster
+    from src.player import Player
+    from src.world_map import WorldMap
+
+
+def move(
+    entity: Union["Player", "Monster"],
+    world_map: "WorldMap",
+    message_log: "MessageLog",
+    winning_position: tuple[int, int, int],
+    argument: Optional[str] = None,
+    world_maps: Optional[Dict[int, "WorldMap"]] = None,
+    game_engine: Optional["GameEngine"] = None,
+) -> Dict[str, Any]:
+    from src.monster import Monster
+    from src.player import Player
+
+    current_game_over_state = False
+    dx, dy = 0, 0
+    if argument == "north":
+        dy = -1
+    elif argument == "south":
+        dy = 1
+    elif argument == "east":
+        dx = 1
+    elif argument == "west":
+        dx = -1
+    else:
+        if isinstance(entity, Player):
+            message_log.add_message(f"Unknown direction: {argument}")
+        return {"game_over": current_game_over_state}
+
+    new_x, new_y = entity.x + dx, entity.y + dy
+
+    if isinstance(entity, Player):
+        floor_before_move = entity.current_floor_id
+
+    if world_map.is_valid_move(new_x, new_y):
+        target_tile = world_map.get_tile(new_x, new_y)
+
+        if (
+            isinstance(entity, Player)
+            and target_tile
+            and target_tile.is_portal
+            and target_tile.portal_to_floor_id is not None
+        ):
+            entity.x = new_x
+            entity.y = new_y
+            new_floor_id = target_tile.portal_to_floor_id
+            entity.current_floor_id = new_floor_id
+            message_log.add_message(
+                f"You step through the portal to floor {new_floor_id}!"
+            )
+            if game_engine and game_engine.ai_logic:
+                game_engine.ai_logic.explorer.mark_portal_as_visited(
+                    new_x, new_y, floor_before_move
+                )
+        elif (
+            target_tile
+            and target_tile.monster
+            and isinstance(entity, Player)
+        ):
+            msg = f"You bump into a {target_tile.monster.name}!"
+            message_log.add_message(msg)
+        elif (
+            target_tile
+            and target_tile.monster
+            and isinstance(entity, Monster)
+        ):
+            pass  # Monster bumps into monster, do nothing
+        elif (
+            target_tile
+            and target_tile.player
+            and isinstance(entity, Monster)
+        ):
+            pass  # Monster bumps into player, do nothing
+        else:
+            if isinstance(entity, Monster):
+                world_map.remove_monster(entity.x, entity.y)
+                world_map.place_monster(entity, new_x, new_y)
+                entity.x = new_x
+                entity.y = new_y
+            elif isinstance(entity, Player):
+                world_map.remove_player(entity.x, entity.y)
+                entity.move(dx, dy)
+                world_map.place_player(entity, entity.x, entity.y)
+                message_log.add_message(f"You move {argument}.")
+
+                if (
+                    entity.x,
+                    entity.y,
+                    entity.current_floor_id,
+                ) == winning_position:
+                    win_tile = world_map.get_tile(
+                        winning_position[0], winning_position[1]
+                    )
+                    if (
+                        win_tile
+                        and win_tile.item
+                        and win_tile.item.properties.get("type") == "quest"
+                    ):
+                        message_log.add_message(
+                            "You reached the Amulet of Yendor's location!"
+                        )
+    else:
+        if isinstance(entity, Player):
+            message_log.add_message("You can't move there.")
+
+    return {"game_over": current_game_over_state}

--- a/src/commands/move_command.py
+++ b/src/commands/move_command.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
+from src.actions.move import move as move_action
+
 from .base_command import Command
 
 if TYPE_CHECKING:
@@ -34,94 +36,12 @@ class MoveCommand(Command):
         )
 
     def execute(self) -> Dict[str, Any]:
-        from src.monster import Monster
-        from src.player import Player
-
-        current_game_over_state = False
-        dx, dy = 0, 0
-        if self.argument == "north":
-            dy = -1
-        elif self.argument == "south":
-            dy = 1
-        elif self.argument == "east":
-            dx = 1
-        elif self.argument == "west":
-            dx = -1
-        else:
-            if isinstance(self.entity, Player):
-                self.message_log.add_message(f"Unknown direction: {self.argument}")
-            return {"game_over": current_game_over_state}
-
-        new_x, new_y = self.entity.x + dx, self.entity.y + dy
-
-        if isinstance(self.entity, Player):
-            floor_before_move = self.player.current_floor_id
-
-        if self.world_map.is_valid_move(new_x, new_y):
-            target_tile = self.world_map.get_tile(new_x, new_y)
-
-            if (
-                isinstance(self.entity, Player)
-                and target_tile
-                and target_tile.is_portal
-                and target_tile.portal_to_floor_id is not None
-            ):
-                self.player.x = new_x
-                self.player.y = new_y
-                new_floor_id = target_tile.portal_to_floor_id
-                self.player.current_floor_id = new_floor_id
-                self.message_log.add_message(
-                    f"You step through the portal to floor {new_floor_id}!"
-                )
-                if self.game_engine and self.game_engine.ai_logic:
-                    self.game_engine.ai_logic.explorer.mark_portal_as_visited(
-                        new_x, new_y, floor_before_move
-                    )
-            elif (
-                target_tile
-                and target_tile.monster
-                and isinstance(self.entity, Player)
-            ):
-                msg = f"You bump into a {target_tile.monster.name}!"
-                self.message_log.add_message(msg)
-            elif (
-                target_tile
-                and target_tile.monster
-                and isinstance(self.entity, Monster)
-            ):
-                pass  # Monster bumps into monster, do nothing
-            elif (
-                target_tile
-                and target_tile.player
-                and isinstance(self.entity, Monster)
-            ):
-                pass  # Monster bumps into player, do nothing
-            else:
-                if isinstance(self.entity, Monster):
-                    self.world_map.remove_monster(self.entity.x, self.entity.y)
-                    self.world_map.place_monster(self.entity, new_x, new_y)
-                elif isinstance(self.entity, Player):
-                    self.entity.move(dx, dy)
-                    self.message_log.add_message(f"You move {self.argument}.")
-
-                    if (
-                        self.player.x,
-                        self.player.y,
-                        self.player.current_floor_id,
-                    ) == self.winning_position:
-                        win_tile = self.world_map.get_tile(
-                            self.winning_position[0], self.winning_position[1]
-                        )
-                        if (
-                            win_tile
-                            and win_tile.item
-                            and win_tile.item.properties.get("type") == "quest"
-                        ):
-                            self.message_log.add_message(
-                                "You reached the Amulet of Yendor's location!"
-                            )
-        else:
-            if isinstance(self.entity, Player):
-                self.message_log.add_message("You can't move there.")
-
-        return {"game_over": current_game_over_state}
+        return move_action(
+            entity=self.entity,
+            world_map=self.world_map,
+            message_log=self.message_log,
+            winning_position=self.winning_position,
+            argument=self.argument,
+            world_maps=self.world_maps,
+            game_engine=self.game_engine,
+        )

--- a/tests/commands/test_move_command.py
+++ b/tests/commands/test_move_command.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 from src.commands.move_command import MoveCommand
 from src.item import Item  # Added Item import
 from src.message_log import MessageLog
+from src.monster import Monster
 from src.player import Player
 from src.tile import Tile
 from src.world_map import WorldMap
@@ -181,6 +182,31 @@ class TestMoveCommand(unittest.TestCase):
         self.assertFalse(
             result.get("game_over", False)
         )  # Game over not set by move, but by take.
+
+    def test_monster_move(self):
+        monster = Monster(name="Goblin", health=10, attack_power=2, x=1, y=1)
+        self.world_map_f0.place_monster(monster, 1, 1)
+
+        move_cmd = MoveCommand(
+            player=self.player,
+            world_map=self.world_map_f0,
+            message_log=self.message_log,
+            winning_position=self.winning_position,
+            argument="north",
+            entity=monster,
+        )
+        move_cmd.execute()
+
+        self.assertEqual(monster.x, 1)
+        self.assertEqual(monster.y, 0)
+        self.assertIsNone(self.world_map_f0.get_tile(1, 1).monster)
+        self.assertIsNotNone(self.world_map_f0.get_tile(1, 0).monster)
+        self.assertEqual(self.world_map_f0.get_tile(1, 0).monster.name, "Goblin")
+
+        # Check for duplicates
+        monsters_on_map = self.world_map_f0.get_monsters()
+        self.assertEqual(len(monsters_on_map), 1)
+        self.assertEqual(monsters_on_map[0], monster)
 
 
 if __name__ == "__main__":

--- a/tests/test_tile.py
+++ b/tests/test_tile.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 from src.tile import ENTITY_SYMBOLS, TILE_SYMBOLS, Tile
 
 
@@ -13,9 +15,6 @@ def test_tile_initialization_custom():
     assert tile.type == "wall"
     assert tile.item is None
     assert tile.monster is None
-
-
-from unittest.mock import MagicMock
 
 
 def test_get_display_info_monster():


### PR DESCRIPTION
When you moved, your old position was not being cleared from the map. This commit fixes the bug by removing you from your old position and placing you in the new position on the `world_map`.