### PR TITLE
fix: Pass message_log to renderer in debug mode

### DIFF
--- a/src/game_engine.py
+++ b/src/game_engine.py
@@ -385,7 +385,7 @@ class GameEngine:
         print("\n--- World Map Layout ---")
         for floor_id, world_map in sorted(self.world_maps.items()):
             print(f"\n--- Floor {floor_id} ---")
-            map_render = world_map.get_map_as_string(self.renderer)
+            map_render = world_map.get_map_as_string(self.renderer, self.message_log)
             if map_render:
                 for row in map_render:
                     print(row)

--- a/src/world_map.py
+++ b/src/world_map.py
@@ -215,7 +215,7 @@ class WorldMap:
                 monsters.append(tile.monster)
         return monsters
 
-    def get_map_as_string(self, renderer) -> list[str]:
+    def get_map_as_string(self, renderer, message_log) -> list[str]:
         """
         Returns a string representation of the map for debugging.
         """
@@ -226,7 +226,7 @@ class WorldMap:
             world_map_to_render=self,
             input_mode="",
             current_command_buffer="",
-            message_log=None,
+            message_log=message_log,
             debug_render_to_list=True,
             current_floor_id=0,  # Floor ID doesn't matter for this
             apply_fog=False,


### PR DESCRIPTION
The debug mode was crashing because the renderer was trying to access the message log, but it was not being passed in debug mode. This change passes the message log to the renderer in debug mode, which fixes the crash.