### PR TITLE
I've fixed the debug mode crash that occurred on input.

### DIFF
--- a/src/game_engine.py
+++ b/src/game_engine.py
@@ -82,7 +82,9 @@ class GameEngine:
             player_symbol=player_symbol,
         )
 
-        self.input_handler = InputHandler(self.renderer.stdscr, self.parser)
+        self.input_handler = InputHandler(
+            self.renderer.stdscr, self.parser, debug_mode=self.debug_mode
+        )
         self.command_processor = CommandProcessor()
         self.input_mode = "normal"  # Added this line
         self.command_buffer = ""  # Added this line

--- a/src/input_handler.py
+++ b/src/input_handler.py
@@ -1,4 +1,5 @@
 import curses
+from typing import Optional
 
 from src.parser import Parser
 
@@ -10,13 +11,14 @@ class InputHandler:
     and uses a Parser to interpret commands.
     """
 
-    def __init__(self, stdscr, parser: Parser):
+    def __init__(self, stdscr: Optional[object], parser: Parser, debug_mode: bool = False):
         """
         Initializes the InputHandler.
         """
         self.stdscr = stdscr
         self.parser = parser
         self.current_command_buffer = ""
+        self.debug_mode = debug_mode
 
     def handle_input_and_get_command(
         self, input_mode: str
@@ -24,6 +26,18 @@ class InputHandler:
         """
         Captures a key press and processes it based on the current input mode.
         """
+        if self.debug_mode:
+            try:
+                command_line = input("> ")
+                if not command_line:
+                    return None
+                return self.parser.parse_command(command_line)
+            except EOFError:
+                return "NO_COMMAND"
+
+        if not self.stdscr:
+            return None
+
         try:
             key = self.stdscr.getkey()
         except curses.error:


### PR DESCRIPTION
The game was crashing because it was trying to use the `curses` library to get user input, but `curses` is not initialized in debug mode.

I fixed this by:
1. Adding a `debug_mode` flag to the `InputHandler`.
2. Changing the `InputHandler` to read from standard input using `input()` instead of `stdscr.getkey()` when in debug mode.
3. Updating the `GameEngine` to correctly propagate the `debug_mode` status to the `InputHandler`.