### PR TITLE
fix(player): Fix AttributeError on Equipment object

### DIFF
--- a/src/input_handler.py
+++ b/src/input_handler.py
@@ -11,7 +11,9 @@ class InputHandler:
     and uses a Parser to interpret commands.
     """
 
-    def __init__(self, stdscr: Optional[object], parser: Parser, debug_mode: bool = False):
+    def __init__(
+        self, stdscr: Optional[object], parser: Parser, debug_mode: bool = False
+    ):
         """
         Initializes the InputHandler.
         """

--- a/src/player.py
+++ b/src/player.py
@@ -57,11 +57,7 @@ class Player:
         """
         Calculates the player's total attack speed, including equipment bonuses.
         """
-        total_attack_speed = self.base_attack_speed
-        for item in self.equipment.values():
-            if item:
-                total_attack_speed += item.attack_speed_bonus
-        return total_attack_speed
+        return self.base_attack_speed + self.equipment.get_total_bonus("attack_speed")
 
     def attack_monster(self, monster: Monster) -> dict[str, str | int | bool]:
         """

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -162,6 +162,21 @@ class TestPlayer(unittest.TestCase):
                 self.player.use_item("Boots of Speed", self.game_engine)
                 self.assertEqual(self.player.get_speed(), 2)
 
+    def test_get_attack_speed(self):
+        self.assertEqual(self.player.get_attack_speed(), 5)
+        item_data = (
+            '{"gloves": {"name": "Gloves of Haste", "description": '
+            '"Gloves that increase your attack speed.", "properties": '
+            '{"type": "equippable", "attack_speed_bonus": 2, "slot": "main_hand"}}}'
+        )
+        with patch("builtins.open", mock_open(read_data=item_data)):
+            self.item_factory = ItemFactory("dummy/path/items.json")
+            gloves = self.item_factory.create_item("gloves")
+            if gloves:
+                self.player.take_item(gloves)
+                self.player.use_item("Gloves of Haste", self.game_engine)
+                self.assertEqual(self.player.get_attack_speed(), 7)
+
     def test_use_invisibility_potion(self):
         item_data = (
             '{"invisibility_potion": {"name": "Invisibility Potion", '


### PR DESCRIPTION
The get_attack_speed method in the Player class was attempting to call .values() on an Equipment object, which caused an AttributeError. This was because it should have been accessing the 'slots' dictionary within the Equipment object.

Refactored the get_attack_speed method to use the existing get_total_bonus method on the Equipment class, which is a cleaner and more consistent approach for calculating stat bonuses from equipment.

Added a new test case to ensure that the player's attack speed is correctly calculated when equipment is worn.