### PR TITLE
Fix crash in monster attack due to missing game_engine

### DIFF
--- a/src/command_processor.py
+++ b/src/command_processor.py
@@ -145,6 +145,7 @@ class CommandProcessor:
         player: "Player",
         world_maps: WorldMaps,
         message_log: "MessageLog",
+        game_engine: "GameEngine",
     ) -> Dict[str, Any]:
         """
         Processes a parsed command tuple for a monster.
@@ -155,6 +156,7 @@ class CommandProcessor:
             player: The Player instance.
             world_maps: All WorldMap instances, keyed by floor_id.
             message_log: The MessageLog instance.
+            game_engine: The GameEngine instance.
 
         Returns:
             Command execution results, typically an empty dictionary or specific
@@ -183,6 +185,7 @@ class CommandProcessor:
                 winning_position=DEFAULT_WINNING_POSITION,
                 argument=argument,
                 entity=monster,
+                game_engine=game_engine,
             )
             return command_instance.execute()
         else:

--- a/src/game_engine.py
+++ b/src/game_engine.py
@@ -144,6 +144,7 @@ class GameEngine:
                             self.player,
                             self.world_maps,
                             self.message_log,
+                            game_engine=self,
                         )
 
     def _update_fog_of_war_visibility(self) -> None:

--- a/tests/test_game_engine.py
+++ b/tests/test_game_engine.py
@@ -401,6 +401,29 @@ class TestGameEngine(unittest.TestCase):
                     self.assertEqual(tile1.is_portal, tile2.is_portal)
                     self.assertEqual(tile1.portal_to_floor_id, tile2.portal_to_floor_id)
 
+    def test_monster_attack_does_not_crash(self):
+        # Arrange
+        monster_mock = MagicMock()
+        monster_mock.health = 10
+        monster_mock.move_energy = 10
+        monster_mock.move_speed = 10
+        monster_mock.ai.get_next_action.return_value = ("attack", None)
+
+        self.mock_world_map_instance.get_monsters.return_value = [monster_mock]
+
+        # Act
+        self.game_engine._handle_monster_actions()
+
+        # Assert
+        self.mock_command_processor_instance.process_monster_command.assert_called_once_with(
+            ("attack", None),
+            monster_mock,
+            self.game_engine.player,
+            self.game_engine.world_maps,
+            self.game_engine.message_log,
+            game_engine=self.game_engine,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The `AttackCommand` for a monster was being created without a reference to the `GameEngine` instance. This caused an `AttributeError: 'NoneType' object has no attribute 'random'` when the monster tried to attack, as the hit chance calculation relies on the game engine's random number generator.

This fix addresses the issue by:
1.  Passing the `GameEngine` instance from `_handle_monster_actions` to the `CommandProcessor`.
2.  Updating `CommandProcessor.process_monster_command` to accept the `game_engine` and forward it to the command constructor.
3.  Adding a unit test to `tests/test_game_engine.py` to simulate a monster attack and assert that the `game_engine` is passed correctly, preventing future regressions.