### PR TITLE
Refactor input_mode to use an Enum

### DIFF
--- a/src/commands/inventory_command.py
+++ b/src/commands/inventory_command.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
+from src.input_mode import InputMode
+
 from .base_command import Command
 
 if TYPE_CHECKING:
@@ -35,8 +37,8 @@ class InventoryCommand(Command):
             return {"game_over": False}
 
         # Toggle inventory mode
-        if self.game_engine.input_mode == "inventory":
-            self.game_engine.input_mode = "normal"
+        if self.game_engine.input_mode == InputMode.INVENTORY:
+            self.game_engine.input_mode = InputMode.MOVEMENT
             if self.game_engine.renderer:
                 self.game_engine.renderer.render_all(
                     player_x=self.player.x,
@@ -49,7 +51,7 @@ class InventoryCommand(Command):
                     current_floor_id=self.player.current_floor_id,
                 )
         else:
-            self.game_engine.input_mode = "inventory"
+            self.game_engine.input_mode = InputMode.INVENTORY
             # The renderer will handle drawing the inventory screen
             # based on the new input_mode.
         return {"game_over": False}

--- a/src/game_engine.py
+++ b/src/game_engine.py
@@ -8,6 +8,7 @@ from src.ai_logic import AILogic
 from src.command_processor import CommandProcessor
 from src.game_state import GameState
 from src.input_handler import InputHandler
+from src.input_mode import InputMode
 from src.message_log import MessageLog
 from src.monster_ai.main import MonsterAILogic
 from src.parser import Parser
@@ -86,7 +87,7 @@ class GameEngine:
             self.renderer.stdscr, self.parser, debug_mode=self.debug_mode
         )
         self.command_processor = CommandProcessor()
-        self.input_mode = "normal"  # Added this line
+        self.input_mode = InputMode.MOVEMENT
         self.command_buffer = ""  # Added this line
 
         self.player = Player(
@@ -296,16 +297,16 @@ class GameEngine:
             command = self.input_handler.handle_input_and_get_command(self.input_mode)
 
             if command == "command_mode":
-                self.input_mode = "command"
+                self.input_mode = InputMode.COMMAND
                 return None
             elif command == "movement_mode":
-                self.input_mode = "normal"
+                self.input_mode = InputMode.MOVEMENT
                 return None
             elif command == "inventory":
-                if self.input_mode == "inventory":
-                    self.input_mode = "normal"
+                if self.input_mode == InputMode.INVENTORY:
+                    self.input_mode = InputMode.MOVEMENT
                 else:
-                    self.input_mode = "inventory"
+                    self.input_mode = InputMode.INVENTORY
                 return None
 
             self.command_buffer = self.input_handler.get_command_buffer()
@@ -355,7 +356,7 @@ class GameEngine:
         if self.ai_active and self.ai_logic:
             ai_path = self.ai_logic.current_path
 
-        if self.input_mode == "inventory":
+        if self.input_mode == InputMode.INVENTORY:
             self.renderer.render_inventory(self.player)
         else:
             self.renderer.render_all(

--- a/src/input_handler.py
+++ b/src/input_handler.py
@@ -1,6 +1,7 @@
 import curses
 from typing import Optional
 
+from src.input_mode import InputMode
 from src.parser import Parser
 
 
@@ -23,7 +24,7 @@ class InputHandler:
         self.debug_mode = debug_mode
 
     def handle_input_and_get_command(
-        self, input_mode: str
+        self, input_mode: InputMode
     ) -> tuple[str, str | None] | None | str:
         """
         Captures a key press and processes it based on the current input mode.
@@ -45,12 +46,12 @@ class InputHandler:
         except curses.error:
             return None
 
-        if input_mode == "inventory":
+        if input_mode == InputMode.INVENTORY:
             if key in ["`", "~", "i", "I"]:
                 return "inventory"  # Special command to toggle inventory
             return None
 
-        if input_mode == "movement":
+        if input_mode == InputMode.MOVEMENT:
             curses.curs_set(0)
             if key in ["KEY_UP", "w", "W"]:
                 return ("move", "north")
@@ -68,7 +69,7 @@ class InputHandler:
                 self.stdscr.clear()
                 return ("resize_event", None)
 
-        elif input_mode == "command":
+        elif input_mode == InputMode.COMMAND:
             curses.curs_set(1)
             if key in ["\n", "\r", "KEY_ENTER"]:
                 if self.current_command_buffer:

--- a/src/input_mode.py
+++ b/src/input_mode.py
@@ -1,0 +1,7 @@
+from enum import Enum, auto
+
+
+class InputMode(Enum):
+    MOVEMENT = auto()
+    COMMAND = auto()
+    INVENTORY = auto()

--- a/src/renderer.py
+++ b/src/renderer.py
@@ -1,6 +1,7 @@
 import curses  # Changed from shutil to curses for terminal size
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
+from src.input_mode import InputMode
 from src.message_log import MessageLog
 from src.tile import TILE_SYMBOLS
 from src.world_map import WorldMap
@@ -56,7 +57,7 @@ class Renderer:
         player_y: int,
         player_health: int,
         world_map_to_render: WorldMap,
-        input_mode: str,
+        input_mode: InputMode,
         current_command_buffer: str,
         message_log: MessageLog,
         current_floor_id: int,
@@ -110,11 +111,11 @@ class Renderer:
 
             output_buffer.append(f"HP: {player_health}")
             output_buffer.append(f"Floor: {current_floor_id}")
-            output_buffer.append(f"MODE: {input_mode.upper()}")
+            output_buffer.append(f"MODE: {input_mode.name.upper()}")
             if ai_state:
                 output_buffer.append(f"AI State: {ai_state}")
                 output_buffer.append(f"Position: ({player_x}, {player_y})")
-            if input_mode == "command":
+            if input_mode == InputMode.COMMAND:
                 output_buffer.append(f"> {current_command_buffer}")
 
             messages_for_debug = message_log.get_messages()  # Use MessageLog method
@@ -234,7 +235,7 @@ class Renderer:
                 self.stdscr.addstr(
                     next_line_y,
                     0,
-                    f"MODE: {input_mode.upper()}",
+                    f"MODE: {input_mode.name.upper()}",
                     curses.color_pair(self.DEFAULT_TEXT_COLOR_PAIR),
                 )
                 next_line_y += 1
@@ -266,7 +267,7 @@ class Renderer:
                     pass
 
         message_start_y = next_line_y
-        if input_mode == "command":
+        if input_mode == InputMode.COMMAND:
             if message_start_y < curses_lines:
                 try:
                     prompt = f"> {current_command_buffer}"

--- a/src/world_map.py
+++ b/src/world_map.py
@@ -1,3 +1,4 @@
+from src.input_mode import InputMode
 from src.monster import Monster
 from src.player import Player
 from src.tile import Tile
@@ -235,7 +236,7 @@ class WorldMap:
             player_y=-1,
             player_health=0,
             world_map_to_render=self,
-            input_mode="",
+            input_mode=InputMode.MOVEMENT,
             current_command_buffer="",
             message_log=message_log,
             debug_render_to_list=True,

--- a/tests/commands/test_inventory_command.py
+++ b/tests/commands/test_inventory_command.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 from src.commands.inventory_command import InventoryCommand
 from src.game_engine import GameEngine
+from src.input_mode import InputMode
 from src.player import Player
 from src.world_map import WorldMap
 
@@ -17,7 +18,7 @@ class TestInventoryCommand(unittest.TestCase):
         self.game_engine.command_buffer = ""
 
     def test_execute_toggles_inventory_mode_on(self):
-        self.game_engine.input_mode = "normal"
+        self.game_engine.input_mode = InputMode.MOVEMENT
         cmd = InventoryCommand(
             player=self.player,
             world_map=self.world_map,
@@ -26,10 +27,10 @@ class TestInventoryCommand(unittest.TestCase):
             game_engine=self.game_engine,
         )
         cmd.execute()
-        self.assertEqual(self.game_engine.input_mode, "inventory")
+        self.assertEqual(self.game_engine.input_mode, InputMode.INVENTORY)
 
     def test_execute_toggles_inventory_mode_off(self):
-        self.game_engine.input_mode = "inventory"
+        self.game_engine.input_mode = InputMode.INVENTORY
         cmd = InventoryCommand(
             player=self.player,
             world_map=self.world_map,
@@ -38,7 +39,7 @@ class TestInventoryCommand(unittest.TestCase):
             game_engine=self.game_engine,
         )
         cmd.execute()
-        self.assertEqual(self.game_engine.input_mode, "normal")
+        self.assertEqual(self.game_engine.input_mode, InputMode.MOVEMENT)
         self.assertTrue(self.game_engine.renderer.render_all.called)
 
 

--- a/tests/test_game_engine.py
+++ b/tests/test_game_engine.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 from src.game_engine import GameEngine
 from src.game_state import GameState
+from src.input_mode import InputMode
 from src.message_log import MessageLog
 from src.world_map import WorldMap
 
@@ -85,7 +86,6 @@ class TestGameEngine(unittest.TestCase):
         self.mock_renderer_instance.stdscr = self.mock_stdscr  # Mock stdscr
         self.mock_command_processor_instance = MockCommandProcessor.return_value
         self.game_engine = GameEngine(map_width=20, map_height=10, debug_mode=False)
-        self.game_engine.input_mode = "normal"
 
         self.game_engine.world_generator = self.mock_world_gen_instance
         self.game_engine.parser = self.mock_parser_instance
@@ -136,6 +136,9 @@ class TestGameEngine(unittest.TestCase):
         self.assertIsInstance(self.game_engine.message_log, MessageLog)
         self.assertEqual(self.game_engine.debug_mode, False)
 
+    def test_initial_input_mode(self):
+        self.assertEqual(self.game_engine.input_mode, InputMode.MOVEMENT)
+
     @patch("src.game_engine.curses.napms")
     def test_run_loop_single_command_then_quit(self, mock_napms):
         self.mock_input_handler_instance.handle_input_and_get_command.side_effect = [
@@ -167,7 +170,7 @@ class TestGameEngine(unittest.TestCase):
             world_map_to_render=self.game_engine.visible_maps[
                 self.game_engine.player.current_floor_id
             ],
-            input_mode="normal",
+            input_mode=InputMode.MOVEMENT,
             current_command_buffer="",
             message_log=self.game_engine.message_log,
             current_floor_id=self.game_engine.player.current_floor_id,

--- a/tests/test_input_handler.py
+++ b/tests/test_input_handler.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 # Assuming src is in PYTHONPATH or tests are run in a way that src can be imported
 from src.input_handler import InputHandler
+from src.input_mode import InputMode
 from src.parser import Parser  # Parser is needed for instantiation, will be mocked
 
 
@@ -17,30 +18,30 @@ class TestInputHandler(unittest.TestCase):
 
     def test_handle_input_movement_mode(self):
         self.mock_stdscr.getkey.return_value = "w"
-        command = self.input_handler.handle_input_and_get_command("movement")
+        command = self.input_handler.handle_input_and_get_command(InputMode.MOVEMENT)
         self.assertEqual(command, ("move", "north"))
 
     def test_handle_input_command_mode(self):
         self.input_handler.current_command_buffer = "take"
         self.mock_stdscr.getkey.return_value = "\n"
         self.mock_parser.parse_command.return_value = ("take", None)
-        command = self.input_handler.handle_input_and_get_command("command")
+        command = self.input_handler.handle_input_and_get_command(InputMode.COMMAND)
         self.assertEqual(command, ("take", None))
         self.assertEqual(self.input_handler.current_command_buffer, "")
 
     def test_handle_input_inventory_mode(self):
         self.mock_stdscr.getkey.return_value = "~"
-        command = self.input_handler.handle_input_and_get_command("inventory")
+        command = self.input_handler.handle_input_and_get_command(InputMode.INVENTORY)
         self.assertEqual(command, "inventory")
 
     def test_switch_to_command_mode(self):
         self.mock_stdscr.getkey.return_value = "`"
-        command = self.input_handler.handle_input_and_get_command("movement")
+        command = self.input_handler.handle_input_and_get_command(InputMode.MOVEMENT)
         self.assertEqual(command, "command_mode")
 
     def test_switch_to_movement_mode(self):
         self.mock_stdscr.getkey.return_value = "\x1b"  # Escape
-        command = self.input_handler.handle_input_and_get_command("command")
+        command = self.input_handler.handle_input_and_get_command(InputMode.COMMAND)
         self.assertEqual(command, "movement_mode")
 
 

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from src.input_mode import InputMode
 from src.message_log import MessageLog
 from src.renderer import Renderer
 from src.tile import Tile
@@ -65,7 +66,7 @@ def setup_renderer():
     player_health = 100
     message_log = MessageLog()
     current_floor_id = 0
-    input_mode = "main"
+    input_mode = InputMode.MOVEMENT
     current_command_buffer = ""
     return (
         renderer,
@@ -113,7 +114,7 @@ def test_render_all_basic_structure(setup_renderer):
     ui_and_message_section = "\n".join(output[world_map.height :])
     assert f"HP: {player_health}" in ui_and_message_section
     assert f"Floor: {current_floor_id}" in ui_and_message_section
-    assert f"MODE: {input_mode.upper()}" in ui_and_message_section
+    assert f"MODE: {input_mode.name.upper()}" in ui_and_message_section
     assert "Msg1" in ui_and_message_section
     assert "Msg2" in ui_and_message_section
 
@@ -217,7 +218,7 @@ def test_render_adapts_to_small_terminal_curses_mode(
             player_y=0,
             player_health=100,
             world_map_to_render=MockWorldMap(large_map_w, large_map_h),
-            input_mode="main",
+            input_mode=InputMode.MOVEMENT,
             current_command_buffer="",
             message_log=MessageLog(),
             current_floor_id=0,


### PR DESCRIPTION
- I replaced the string-based `input_mode` with an Enum to improve type safety and prevent you from using invalid modes.
- The valid input modes are now `INVENTORY`, `MOVEMENT`, and `COMMAND`.
- The default input mode is `MOVEMENT`.
- I also added a test to ensure the game engine initializes with the correct default mode.