### PR TITLE
Fix game crash on game over

### DIFF
--- a/src/game_engine.py
+++ b/src/game_engine.py
@@ -277,7 +277,7 @@ class GameEngine:
             else:
                 self._render(ai_state=ai_state)
                 curses.napms(2000)
-                self.input_handler.handle_input_and_get_command()
+                self.input_handler.handle_input_and_get_command(InputMode.GAME_OVER)
                 self.game_state = GameState.QUIT
 
         elif self.game_state == GameState.QUIT and self.debug_mode:

--- a/src/input_handler.py
+++ b/src/input_handler.py
@@ -46,6 +46,9 @@ class InputHandler:
         except curses.error:
             return None
 
+        if input_mode == InputMode.GAME_OVER:
+            return None
+
         if input_mode == InputMode.INVENTORY:
             if key in ["`", "~", "i", "I"]:
                 return "inventory"  # Special command to toggle inventory


### PR DESCRIPTION
The game was crashing on the game over screen because the `handle_input_and_get_command` method was being called without the required `input_mode` argument.

This change fixes the issue by:
- Passing `InputMode.GAME_OVER` to the `handle_input_and_get_command` method in `game_engine.py`.
- Adding a case for `InputMode.GAME_OVER` in `input_handler.py` to gracefully handle the input.